### PR TITLE
add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM python:slim AS builder
+
+COPY Makefile /app/
+
+RUN apt update -yq \
+    && apt install -yq bzip2 cmake g++ make wget \
+    && pip wheel -w /app/ dlib \
+    && make -C /app/ download-models
+
+FROM python:slim
+
+COPY --from=builder /app/dlib*.whl /tmp/
+COPY --from=builder /app/vendor/ /app/vendor/
+COPY facerecognition-external-model.py /app/
+
+RUN pip install flask \
+    && pip install --no-index -f /tmp/ dlib \
+    && rm /tmp/dlib*.whl
+
+WORKDIR /app/
+
+EXPOSE 5000
+
+ENV API_KEY=some-super-secret-api-key
+ENV FLASK_APP=facerecognition-external-model.py
+
+CMD flask run -h 0.0.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY --from=builder /app/dlib*.whl /tmp/
 COPY --from=builder /app/vendor/ /app/vendor/
 COPY facerecognition-external-model.py /app/
 
-RUN pip install flask \
+RUN pip install flask numpy \
     && pip install --no-index -f /tmp/ dlib \
     && rm /tmp/dlib*.whl
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ So, please. Think seriously about data security before running this service outs
 
 ## Docker
 The fastest way to get this up and running without manual installation and configuration is a docker image. You only have to define the api key and the exposed port:
-```
-docker build -t facerecognition https://github.com/matiasdelellis/facerecognition-external-model.git &&
-docker run -i --rm -p 8080:5000 -e API_KEY="super-secret" facerecognition
+```sh
+docker build -t facerecognition https://github.com/matiasdelellis/facerecognition-external-model.git
+docker run --rm -i -p 8080:5000 -e API_KEY="super-secret" facerecognition
+# possible is also api key as file
+docker run --rm -i -p 8080:5000 -v /path/to/api.key:/app/api.key facerecognition
 ```
 
 ## Manual

--- a/README.md
+++ b/README.md
@@ -7,12 +7,20 @@ The images are sent via POST, and are immediately deleted after being analyzed. 
 
 So, please. Think seriously about data security before running this service outside of your local network.
 
-## Dependencies
+## Docker
+The fastest way to get this up and running without manual installation and configuration is a docker image. You only have to define the api key and the exposed port:
+```
+docker build -t facerecognition https://github.com/matiasdelellis/facerecognition-external-model.git &&
+docker run -i --rm -p 8080:5000 -e API_KEY="super-secret" facerecognition
+```
+
+## Manual
+### Dependencies
 * python3-flask
 * python3-dlib
 * python3-numpy
 
-## Install
+### Install
 Just clone this repo and install the resnet models.
 ```
 [matias@laptop ~]$ git clone https://github.com/matiasdelellis/facerecognition-external-model.git
@@ -36,10 +44,8 @@ bzip2 -d vendor/models/1/shape_predictor_5_face_landmarks.dat.bz2
 [matias@laptop facerecognition-external-model]$
 ```
 
-## Usage
-
-### Configure Service
-
+### Usage
+#### Configure Service
 You must generate a shared api key and save it in the file `api.key`.
 ```
 [matias@laptop facerecognition-external-model]$ openssl rand -base64 32
@@ -68,7 +74,7 @@ Launch the service indicating this IP and some TCP port such as `8080`.
 
 Note that this service is running on `http://192.168.1.103:8080/`
 
-### Test
+## Test
 You can test if the service is running using curl.
 ```
 [matias@laptop ~]$ curl http://192.168.1.103:8080/welcome
@@ -87,7 +93,7 @@ If curl responds something like the following, surely you have a firewall with p
 curl: (7) Failed to connect to 192.168.1.103 port 8080: No route to host
 ```
 
-### Use
+## Use
 If the service is accessible, you can now configure Nextcloud, indicating that you have an external model at this address, and the shared api key. So, you must add these lines to your `config/config.php` file.
 ```
 [matias@nube ~]$ cat nextcloud/config/config.php

--- a/facerecognition-external-model.py
+++ b/facerecognition-external-model.py
@@ -25,8 +25,11 @@ app = Flask(__name__)
 def require_appkey(view_function):
     @wraps(view_function)
     def decorated_function(*args, **kwargs):
-        with open('api.key', 'r') as apikey:
-            key = apikey.read().replace('\n', '')
+        if 'API_KEY' in os.environ:
+            key = os.environ.get('API_KEY')
+        else:
+            with open('api.key', 'r') as apikey:
+                key = apikey.read().replace('\n', '')
         if request.headers.get('x-api-key') and request.headers.get('x-api-key') == key:
             return view_function(*args, **kwargs)
         else:


### PR DESCRIPTION
Add Dockerfile to get the external model fast up and running. One missing part is that the Nextcloud addon requires bzip2 and pdlib upon install and setup which is not the case on the official docker image `nextcloud:fpm-alpine`.