### PR TITLE
give priority to api.key file

### DIFF
--- a/facerecognition-external-model.py
+++ b/facerecognition-external-model.py
@@ -131,12 +131,13 @@ def open_dlib_models():
 def require_appkey(view_function):
     @wraps(view_function)
     def decorated_function(*args, **kwargs):
-        if 'API_KEY' in os.environ:
-            key = os.environ.get('API_KEY')
-        else:
+        key = ''
+        if os.path.isfile('api.key'):
             with open('api.key', 'r') as apikey:
                 key = apikey.read().replace('\n', '')
-        if request.headers.get('x-api-key') and request.headers.get('x-api-key') == key:
+        elif 'API_KEY' in os.environ:
+            key = os.environ.get('API_KEY')
+        if key and request.headers.get('x-api-key') and request.headers.get('x-api-key') == key:
             return view_function(*args, **kwargs)
         else:
             abort(401)


### PR DESCRIPTION
in the docker image the API_KEY is set to some value, even though I created the docker with `-v apikey:/app/api.key` and the values were correct. So, the docker image was returning 401 as the API_KEY value wasn't matching the correct value from `x-api-key`.