### PR TITLE
Change dockerfile to allow running in IPv6 docker setups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,4 @@ EXPOSE 5000
 ENV API_KEY=some-super-secret-api-key
 ENV FLASK_APP=facerecognition-external-model.py
 
-CMD flask run -h 0.0.0.0
+CMD flask run -h ::


### PR DESCRIPTION
Changes the flask IP to "::" so it will (also) work with IPv6.