### PR TITLE
Fixed boot issues when running multiple workers in parallel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ ENV GUNICORN_WORKERS="${GUNICORN_WORKERS}"\
     API_KEY=some-super-secret-api-key\
     FLASK_APP=facerecognition-external-model.py
 
-CMD ["gunicorn"  , "-c", "gunicorn_config.py", "facerecognition-external-model:app"]
+ENTRYPOINT ["gunicorn"  , "-c", "gunicorn_config.py", "facerecognition-external-model:app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,13 @@ FROM python:slim
 
 COPY --from=builder /app/dlib*.whl /tmp/
 COPY --from=builder /app/vendor/ /app/vendor/
-COPY facerecognition-external-model.py /app/
-COPY gunicorn_config.py /app/
 
 RUN pip install flask numpy gunicorn \
     && pip install --no-index -f /tmp/ dlib \
     && rm /tmp/dlib*.whl
+
+COPY facerecognition-external-model.py /app/
+COPY gunicorn_config.py /app/
 
 WORKDIR /app/
 

--- a/facerecognition-external-model.py
+++ b/facerecognition-external-model.py
@@ -21,15 +21,7 @@ FACE_REC: object = None
 
 MAX_IMG_SIZE = 3840 * 2160
 
-# Check image folder
 folder_path = "images"
-if not os.path.exists(folder_path):
-    os.mkdir(folder_path)
-
-# Clean old files if exists.
-for filename in os.listdir(folder_path):
-    os.unlink(os.path.join(folder_path, filename))
-
 
 # Model service
 app = Flask(__name__)

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -10,3 +10,14 @@ threads = int(os.getenv("GUNICORN_WORKERS", 1))
 reload = bool("false")
 
 timeout = int(os.getenv("REQ_TIMEOUT", 300))
+
+def on_starting(server):
+    # Check image folder
+    folder_path = "images"
+    if not os.path.exists(folder_path):
+        server.log.debug("Creating directory for temporary files.")
+        os.mkdir(folder_path)
+    # Clean old files if exists.
+    server.log.debug("Cleaning up old temporary files.")
+    for filename in os.listdir(folder_path):
+        os.unlink(os.path.join(folder_path, filename))


### PR DESCRIPTION
This fixes an issue when multiple workers try to create `folder_path` during boot:
```
[2024-10-06 12:30:10 +0200] [7] [ERROR] Exception in worker process
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/gunicorn/arbiter.py", line 608, in spawn_worker
    worker.init_process()
  File "/usr/local/lib/python3.12/site-packages/gunicorn/workers/gthread.py", line 94, in init_process
    super().init_process()
  File "/usr/local/lib/python3.12/site-packages/gunicorn/workers/base.py", line 135, in init_process
    self.load_wsgi()
  File "/usr/local/lib/python3.12/site-packages/gunicorn/workers/base.py", line 147, in load_wsgi
    self.wsgi = self.app.wsgi()
                ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/gunicorn/app/base.py", line 66, in wsgi
    self.callable = self.load()
                    ^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/gunicorn/app/wsgiapp.py", line 57, in load
    return self.load_wsgiapp()
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/gunicorn/app/wsgiapp.py", line 47, in load_wsgiapp
    return util.import_app(self.app_uri)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/gunicorn/util.py", line 370, in import_app
    mod = importlib.import_module(module)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 995, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/app/facerecognition-external-model.py", line 27, in <module>
    os.mkdir(folder_path)
FileExistsError: [Errno 17] File exists: 'images'
[2024-10-06 12:30:10 +0200] [7] [INFO] Worker exiting (pid: 7)
```
or when a worker that is booting cleans up temporary files that are being used by other workers
```
[2024-10-06 12:30:41,243] ERROR in app: Exception on /detect [POST]
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/flask/app.py", line 1473, in wsgi_app
    response = self.full_dispatch_request()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/flask/app.py", line 882, in full_dispatch_request
    rv = self.handle_user_exception(e)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/flask/app.py", line 880, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/flask/app.py", line 865, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/facerecognition-external-model.py", line 140, in decorated_function
    return view_function(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/facerecognition-external-model.py", line 166, in detect_faces
    os.remove(image_path)
FileNotFoundError: [Errno 2] No such file or directory: 'images/oc_tmp_kaGkKc'
::ffff:192.168.0.136 - - [06/Oct/2024:12:30:41 +0200] 'POST /detect HTTP/1.1' 500 265 in 19982ms
[2024-10-06 12:30:41 +0200] [73] [INFO] Worker exiting (pid: 73)
```

Some additional content:
* improved docker build efficiency (usually you just change `facerecognition-external-model.py` - no need to run pip install)
* gunicorn is now an `ENTRYPOINT` (easier to pass additional arguments)